### PR TITLE
Provision of fragment length distribution parameters

### DIFF
--- a/pipeline_interface.yaml
+++ b/pipeline_interface.yaml
@@ -1,10 +1,8 @@
 protocol_mapping:
-  # TODO: will this work for handling options/flags? (before it was <script> <flags>)
-  # TODO (cont.): whereas now it's <name> <flags>
   RNA-seq: >
-    rnaBitSeq -f;
-    rnaKallisto;
-    rnaTopHat -f
+    rnaBitSeq.py -f;
+    rnaKallisto.py;
+    rnaTopHat.py -f
   SMART:  >
     rnaBitSeq.py -f;
     rnaTopHat.py -f
@@ -14,12 +12,10 @@ protocol_mapping:
   QUANT-SEQ: >
     rnaBitSeq.py -f --quantseq;
     rnaKallisto.py --quantseq
-  # TODO: will this work for handling options/flags? (before it was <script> <flags>)
-  # TODO (cont.): whereas now it's <name> <flags>
-  rnaKallisto: rnaKallisto
-  rnaBitSeq: rnaBitSeq -f
-  rnaTopHat: rnaTopHat -f
-  rnaESAT: rnaESAT
+  rnaKallisto: rnaKallisto.py
+  rnaBitSeq: rnaBitSeq.py -f
+  rnaTopHat: rnaTopHat.py -f
+  rnaESAT: rnaESAT.py
 
 pipelines:
   rnaBitSeq.py:

--- a/pipeline_interface.yaml
+++ b/pipeline_interface.yaml
@@ -1,8 +1,10 @@
 protocol_mapping:
+  # TODO: will this work for handling options/flags? (before it was <script> <flags>)
+  # TODO (cont.): whereas now it's <name> <flags>
   RNA-seq: >
-    rnaBitSeq.py -f;
-    rnaKallisto.py;
-    rnaTopHat.py -f
+    rnaBitSeq -f;
+    rnaKallisto;
+    rnaTopHat -f
   SMART:  >
     rnaBitSeq.py -f;
     rnaTopHat.py -f
@@ -12,10 +14,12 @@ protocol_mapping:
   QUANT-SEQ: >
     rnaBitSeq.py -f --quantseq;
     rnaKallisto.py --quantseq
-  rnaKallisto: rnaKallisto.py
-  rnaBitSeq: rnaBitSeq.py -f
-  rnaTopHat: rnaTopHat.py -f
-  rnaESAT: rnaESAT.py
+  # TODO: will this work for handling options/flags? (before it was <script> <flags>)
+  # TODO (cont.): whereas now it's <name> <flags>
+  rnaKallisto: rnaKallisto
+  rnaBitSeq: rnaBitSeq -f
+  rnaTopHat: rnaTopHat -f
+  rnaESAT: rnaESAT
 
 pipelines:
   rnaBitSeq.py:

--- a/src/rnaKallisto.py
+++ b/src/rnaKallisto.py
@@ -198,7 +198,11 @@ def process(sample, pipeline_config, args):
 										sample.transcriptome + "_kallisto_index.idx")
 
 	# Get the parameterizable options for the pipeline.
-	cmdl_opts = vars(args)
+	# Exclude null values from the namespace, as these suggest that the option
+	# was not used. Note that this may not work smoothly for flag-like options
+	# and for options for which the default is non-null (e.g., 0 automatically
+	# for a numeric value. Such cases would need to be handled separately.)
+	cmdl_opts = {opt: arg for opt, arg in vars(args).items() if arg is not None}
 	pipe_opts = pipeline_config.parameters
 	getopt = partial(get_parameter, param_pools=[sample, cmdl_opts, pipe_opts])
 	n_boot = getopt("n_boot")

--- a/src/rnaKallisto.py
+++ b/src/rnaKallisto.py
@@ -202,8 +202,8 @@ def process(sample, pipeline_config, args):
 	pipe_opts = pipeline_config.parameters
 	getopt = partial(get_parameter, param_pools=[sample, cmdl_opts, pipe_opts])
 	n_boot = getopt("n_boot")
-	size = getopt("fragment_length", use_null=True)
-	sdev = getopt("fragment_length_sdev", use_null=True)
+	size = getopt("fragment_length", on_missing=None, error=False)
+	sdev = getopt("fragment_length_sdev", on_missing=None, error=False)
 	if not sample.paired and (size is None or sdev is None):
 		raise ValueError("For single-end data, estimates for mean and standard deviation of fragment size are required.")
 

--- a/src/rnaKallisto.yaml
+++ b/src/rnaKallisto.yaml
@@ -13,6 +13,4 @@ tools:
 parameters:
   # which trimmer to use: choose between ["trimmomatic", "skewer"]
   trimmer: "skewer"
-  length: 50
-  sdev: 20
   n_boot: 0

--- a/src/rnaKallisto.yaml
+++ b/src/rnaKallisto.yaml
@@ -14,3 +14,5 @@ parameters:
   # which trimmer to use: choose between ["trimmomatic", "skewer"]
   trimmer: "skewer"
   n_boot: 0
+  fragment_length: 300
+  fragment_lentgh_sdev: 20

--- a/src/rnaKallisto.yaml
+++ b/src/rnaKallisto.yaml
@@ -13,3 +13,6 @@ tools:
 parameters:
   # which trimmer to use: choose between ["trimmomatic", "skewer"]
   trimmer: "skewer"
+  length: 50
+  sdev: 20
+  n_boot: 0


### PR DESCRIPTION
`kallisto` needs fragment length distribution parameters for single-end data. Now we can grab those data from a sample, from the command-line, or from the pipeline config file.